### PR TITLE
develop > rubocop-fixes

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Devise
+module Users
   class ConfirmationsController < Devise::ConfirmationsController
     # GET /resource/confirmation/new
     # def new

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Devise
+module Users
   class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     # You should configure your model like this:
     # devise :omniauthable, omniauth_providers: [:twitter]

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Devise
+module Users
   class PasswordsController < Devise::PasswordsController
     # GET /resource/password/new
     # def new

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Devise
+module Users
   # app > controllers > users > registrations_controller\
   class RegistrationsController < Devise::RegistrationsController
     # before_action :configure_sign_up_params, only: [:create]

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Devise
+module Users
   # app > controllers > users > sessionscontroller
   class SessionsController < Devise::SessionsController
     # before_action :configure_sign_in_params, only: [:create]

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Devise
+module Users
   class UnlocksController < Devise::UnlocksController
     # GET /resource/unlock/new
     # def new


### PR DESCRIPTION
- added nested name spacing instead of '::'